### PR TITLE
break loop if the element is removed

### DIFF
--- a/mini-toastr.js
+++ b/mini-toastr.js
@@ -5,6 +5,7 @@ export function fadeOut (element, cb) {
     if (element.parentNode) {
       element.parentNode.removeChild(element)
       if (cb) cb()
+      return
     }
   } else {
     element.style.opacity = 0.9


### PR DESCRIPTION
Currently the toastr is stuck in an endless loop since the opacity is eventually always <= 0.1.
This will stop the loop if the element child element is removed.